### PR TITLE
Specify `void` in empty function declarations

### DIFF
--- a/libfiu/backtrace.c
+++ b/libfiu/backtrace.c
@@ -84,14 +84,14 @@ void *get_func_addr(const char *func_name)
 /* Ugly but useful conversion from function pointer to void *.
  * This is not guaranteed by the standard, but has to work on all platforms
  * where we support backtrace(), because that function assumes it so. */
-static void *fp_to_voidp(void (*funcp)())
+static void *fp_to_voidp(void (*funcp)(void))
 {
 	unsigned char **p;
 	p = (unsigned char **)&funcp;
 	return *p;
 }
 
-int backtrace_works(void (*caller)())
+int backtrace_works(void (*caller)(void))
 {
 	/* We remember the result so we don't have to compute it over an over
 	 * again, we know it doesn't change. */

--- a/libfiu/fiu.c
+++ b/libfiu/fiu.c
@@ -455,7 +455,7 @@ int fiu_enable_stack(const char *name, int failnum, void *failinfo,
 	if (func_pos_in_stack != -1)
 		return -1;
 
-	if (backtrace_works((void (*)())fiu_enable_stack) == 0)
+	if (backtrace_works((void (*)(void))fiu_enable_stack) == 0)
 		return -1;
 
 	// We need either get_func_end() or get_func_start() to work, see
@@ -483,7 +483,7 @@ int fiu_enable_stack_by_name(const char *name, int failnum, void *failinfo,
 	/* We need to check this here instead of relying on the test within
 	 * fiu_enable_stack() in case it is inlined; that would fail the check
 	 * because fiu_enable_stack() would not be in the stack. */
-	if (backtrace_works((void (*)())fiu_enable_stack_by_name) == 0)
+	if (backtrace_works((void (*)(void))fiu_enable_stack_by_name) == 0)
 		return -1;
 
 	fp = get_func_addr(func_name);

--- a/libfiu/hash.c
+++ b/libfiu/hash.c
@@ -344,7 +344,7 @@ struct cache {
 	pthread_rwlock_t lock;
 };
 
-struct cache *cache_create()
+struct cache *cache_create(void)
 {
 	struct cache *c;
 

--- a/libfiu/hash.h
+++ b/libfiu/hash.h
@@ -21,7 +21,7 @@ bool hash_del(hash_t *h, const char *key);
 
 typedef struct cache cache_t;
 
-cache_t *cache_create();
+cache_t *cache_create(void);
 bool cache_resize(struct cache *c, size_t new_size);
 void cache_free(cache_t *c);
 

--- a/libfiu/internal.h
+++ b/libfiu/internal.h
@@ -24,6 +24,6 @@ void *get_func_addr(const char *func_name);
 
 /* Do the above backtrace-related functions work?
  * Takes a pointer to the caller so it can verify it's on the stack. */
-int backtrace_works(void (*caller)());
+int backtrace_works(void (*caller)(void));
 
 #endif

--- a/tests/generated/tests/fread.conf
+++ b/tests/generated/tests/fread.conf
@@ -2,7 +2,7 @@
 [fread]
 fp: posix/stdio/rw/fread
 include: stdio.h
-prep: unsigned char buf[1024]; ssize_t r; FILE *fp = fopen("/dev/zero", "r");
+prep: unsigned char buf[1024]; size_t r; FILE *fp = fopen("/dev/zero", "r");
 call: r = fread(buf, 1, 1024, fp);
 success_cond: r == 1024 && ferror(fp) == 0
 failure_cond: r == 0 && ferror(fp) != 0

--- a/tests/test-enable_stack.c
+++ b/tests/test-enable_stack.c
@@ -6,7 +6,7 @@
 #include <fiu-control.h>
 #include <fiu.h>
 
-int __attribute__((noinline)) func1()
+int __attribute__((noinline)) func1(void)
 {
 	/*
 	int nptrs;
@@ -18,7 +18,7 @@ int __attribute__((noinline)) func1()
 	return fiu_fail("fp-1") != 0;
 }
 
-int __attribute__((noinline)) func2()
+int __attribute__((noinline)) func2(void)
 {
 	return func1();
 }

--- a/tests/test-enable_stack_by_name.c
+++ b/tests/test-enable_stack_by_name.c
@@ -6,7 +6,7 @@
 #include <fiu-control.h>
 #include <fiu.h>
 
-int __attribute__((noinline)) func1()
+int __attribute__((noinline)) func1(void)
 {
 	/*
 	int nptrs;
@@ -18,7 +18,7 @@ int __attribute__((noinline)) func1()
 	return fiu_fail("fp-1") != 0;
 }
 
-int __attribute__((noinline)) func2()
+int __attribute__((noinline)) func2(void)
 {
 	return func1();
 }

--- a/tests/test-ferror.c
+++ b/tests/test-ferror.c
@@ -11,7 +11,7 @@ int test(const char *prefix)
 	FILE *fp = fopen("/dev/zero", "r");
 
 	unsigned char buf[1024];
-	ssize_t r;
+	size_t r;
 
 	fiu_enable("posix/stdio/rw/fread", 1, (void *)EIO, 0);
 

--- a/tests/test-parallel-wildcard.c
+++ b/tests/test-parallel-wildcard.c
@@ -150,7 +150,7 @@ void *enabler(void *unused)
 	return NULL;
 }
 
-void disable_all()
+void disable_all(void)
 {
 	int high;
 

--- a/tests/test-parallel.c
+++ b/tests/test-parallel.c
@@ -123,7 +123,7 @@ void *enabler(void *unused)
 	return NULL;
 }
 
-void disable_all()
+void disable_all(void)
 {
 	int i = 0;
 


### PR DESCRIPTION
1. Look in the `tests` subfolder for more functions that have empty parameter lists but are not explicitly marked with `void`, since `CC=clang make` does not build the tests by default.
2. Correct the return type of `fread` in `tests/test-ferror.c` (line 14) and `tests/generated/tests/fread.conf` (line 5) from `ssize_t` to `size_t`. This issue was discovered while building `libfiu` on FreeBSD 14.3.

`clang -Wall` includes `-Wstrict-prototypes`, which complains about
declarations with empty parameters, like `void func()`.

Modern C standards say those should be explicitly marked with `void`,
e.g. `void func(void)`.

This patch updates all such declarations so they comply to new
standards, and as a result, building with clang (or
`-Wstrict-prototypes`) no longer shows warnings.

#5 