### PR TITLE
Fix inconsistent shebang in test scripts.

### DIFF
--- a/tests/utils/test-basic_run.sh
+++ b/tests/utils/test-basic_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/tests/utils/wrap
+++ b/tests/utils/wrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Wrap the utilities (fiu-ctrl, fiu-ls, fiu-run) so that we can run them
 # easily from within the development tree, agains the locally-built libraries.


### PR DESCRIPTION
The scripts `tests/utils/wrap` and `tests/utils/test-basic_run.sh` used `#!/bin/bash`, which was inconsistent with other libfiu scripts.  

They have been updated to use `#!/usr/bin/env bash` for consistency.