### PR TITLE
Specify `void` in empty function declarations.

### DIFF
--- a/preload/posix/generate
+++ b/preload/posix/generate
@@ -109,6 +109,8 @@ class Function:
 
 		# extract params names and types
 		paramst = ', '.join([i[0] for i in self.params_info])
+		if not paramst:
+			paramst = 'void'
 		paramsn = ', '.join([i[1] for i in self.params_info])
 
 		f.write('mkwrap_top(%s, %s, (%s), (%s), (%s), (%s))\n' % \


### PR DESCRIPTION
Some functions (`munlockall`, `fork`, `tmpfile`, `tmpfile64`, and `getchar`) have no parameters. In such cases, `preload/posix/generate` would produce an empty `PARAMST`, which results in `-Wstrict-prototypes` warnings when compiling the generated `_fiu_init_##NAME(void)` functions to retrieve their original addresses.

`clang -Wall` includes `-Wstrict-prototypes`, which complains about declarations with empty parameters, like `void func()`.

Modern C standards say those should be explicitly marked with `void`, e.g. `void func(void)`.

This patch updates the generator to set `PARAMST` to `void` when empty, and as a result, building with clang (or
`-Wstrict-prototypes`) no longer shows warnings.

#5
#6