### PR TITLE
Make `ALL_CFLAGS` consistent across Makefiles.

### DIFF
--- a/preload/posix/Makefile
+++ b/preload/posix/Makefile
@@ -1,15 +1,20 @@
 
-CFLAGS += -std=c99 -Wall -O3
+CFLAGS += -std=c99 -pedantic -Wall
 ALL_CFLAGS = -D_XOPEN_SOURCE=600 -fPIC -DFIU_ENABLE=1 \
 		-D_LARGEFILE64_SOURCE=1 -I. -I../../libfiu/ \
 		$(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
-ifdef DEBUG
-ALL_CFLAGS += -g
-endif
+# Optimization CFLAGS, only used when doing a non-debug build.
+OPT_CFLAGS = -O3
 
-ifdef PROFILE
-ALL_CFLAGS += -g -pg -fprofile-arcs -ftest-coverage
+ifdef DEBUG
+	ALL_CFLAGS += -g
+else
+	ifdef PROFILE
+		ALL_CFLAGS += -g -pg -fprofile-arcs -ftest-coverage
+	else
+		ALL_CFLAGS += $(OPT_CFLAGS)
+	endif
 endif
 
 ifdef POSIX_TRACE

--- a/preload/run/Makefile
+++ b/preload/run/Makefile
@@ -1,15 +1,20 @@
 
-CFLAGS += -std=c99 -Wall -O3
+CFLAGS += -std=c99 -pedantic -Wall
 ALL_CFLAGS = -D_XOPEN_SOURCE=600 -fPIC -DFIU_ENABLE=1 \
 		-I. -I../../libfiu/ \
 		$(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
-ifdef DEBUG
-ALL_CFLAGS += -g
-endif
+# Optimization CFLAGS, only used when doing a non-debug build.
+OPT_CFLAGS = -O3
 
-ifdef PROFILE
-ALL_CFLAGS += -g -pg -fprofile-arcs -ftest-coverage
+ifdef DEBUG
+	ALL_CFLAGS += -g
+else
+	ifdef PROFILE
+		ALL_CFLAGS += -g -pg -fprofile-arcs -ftest-coverage
+	else
+		ALL_CFLAGS += $(OPT_CFLAGS)
+	endif
 endif
 
 # prefix for installing the binaries

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,12 +3,17 @@ CFLAGS += -std=c99 -pedantic -Wall
 ALL_CFLAGS = -I../libfiu/ -L../libfiu/ \
 	-D_XOPEN_SOURCE=600 -D_GNU_SOURCE -fPIC -DFIU_ENABLE=1 $(CFLAGS)
 
-ifdef DEBUG
-ALL_CFLAGS += -g
-endif
+# Optimization CFLAGS, only used when doing a non-debug build.
+OPT_CFLAGS = -O3
 
-ifdef PROFILE
-ALL_CFLAGS += -g -pg -fprofile-arcs -ftest-coverage
+ifdef DEBUG
+	ALL_CFLAGS += -g
+else
+	ifdef PROFILE
+		ALL_CFLAGS += -g -pg -fprofile-arcs -ftest-coverage
+	else
+		ALL_CFLAGS += $(OPT_CFLAGS)
+	endif
 endif
 
 ifneq ($(V), 1)

--- a/tests/generated/Makefile
+++ b/tests/generated/Makefile
@@ -3,12 +3,17 @@ CFLAGS += -std=c99 -pedantic -Wall
 ALL_CFLAGS = -I../../libfiu/ -L../../libfiu/ \
 	-D_XOPEN_SOURCE=600 -D_GNU_SOURCE -fPIC -DFIU_ENABLE=1 $(CFLAGS)
 
-ifdef DEBUG
-ALL_CFLAGS += -g
-endif
+# Optimization CFLAGS, only used when doing a non-debug build.
+OPT_CFLAGS = -O3
 
-ifdef PROFILE
-ALL_CFLAGS += -g -pg -fprofile-arcs -ftest-coverage
+ifdef DEBUG
+	ALL_CFLAGS += -g
+else
+	ifdef PROFILE
+		ALL_CFLAGS += -g -pg -fprofile-arcs -ftest-coverage
+	else
+		ALL_CFLAGS += $(OPT_CFLAGS)
+	endif
 endif
 
 ifneq ($(V), 1)


### PR DESCRIPTION
The Makefiles under `preload/posix`, `preload/run`, `tests`, and `tests/generated` folders handled `ALL_CFLAGS` inconsistently. Update them to follow the same pattern used in `libfiu/Makefile` for consistency.